### PR TITLE
Update regex for 3.10 and master -> main rename

### DIFF
--- a/roundup/github.py
+++ b/roundup/github.py
@@ -18,7 +18,7 @@ else:
 URL_RE = re.compile(r'https://github.com/python/cpython/pull/(?P<number>\d+)')
 VERBS = r'(?:\b(?P<verb>close[sd]?|closing|fix(?:e[sd])?|)\s+)?'
 ISSUE_RE = re.compile(r'%sbpo-(?P<issue_id>\d+)' % VERBS, re.I|re.U)
-BRANCH_RE = re.compile(r'(2\.\d|3\.\d|master)', re.I)
+BRANCH_RE = re.compile(r'(3\.\d+|main)', re.I)
 
 # Maximum number of bpo issues linked to a PR
 ISSUE_LIMIT = 10
@@ -379,7 +379,7 @@ class Push(Event):
         """
         self.set_roundup_user()
         commits = self.data.get('commits', [])
-        ref = self.data.get('ref', 'refs/heads/master')
+        ref = self.data.get('ref', 'refs/heads/main')
         # messages dictionary maps issue number to a tuple containing
         # the message to be posted as a comment and a boolean flag informing
         # if the issue should be 'closed'


### PR DESCRIPTION
I think this should be enough to restore commit messages to bpo after the creation of the 3.10 branch and the rename of `master` to `main`.  It's completely untested and I'm not even sure *how* to test it, though.

/cc @ewdurbin, @ezio-melotti 